### PR TITLE
Expose Option to Allow Getting Logger from Context

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -15,8 +15,8 @@ type Option struct {
 	// optional: logrus logger (default: logrus.StandardLogger())
 	Logger *logrus.Logger
 
-	// optional: if set, always use the logger from PerHandleLogger() in Handle()
-	PerHandleLogger func(ctx context.Context) *logrus.Logger
+	// optional: if set, GetLogger will be used to get the logger at each call to Handle
+	GetLogger func(ctx context.Context) *logrus.Logger
 
 	// optional: customize json payload builder
 	Converter Converter
@@ -65,8 +65,8 @@ func (h *LogrusHandler) Handle(ctx context.Context, record slog.Record) error {
 	args := converter(h.option.AddSource, h.option.ReplaceAttr, h.attrs, h.groups, &record)
 
 	logger := h.option.Logger
-	if h.option.PerHandleLogger != nil {
-		logger = h.option.PerHandleLogger(ctx)
+	if h.option.GetLogger != nil {
+		logger = h.option.GetLogger(ctx)
 	}
 
 	logrus.NewEntry(logger).


### PR DESCRIPTION
This PR exposes a `GetLogger()` function in the Option. `GetLogger()` allows the handler to get a logger instance from context.

**Usage**

Our application uses Logrus and configures it with lots of contextual fields. The logger instance is stored on the context per request/message handling.
 
This allows us to hook downstream libraries that use slog to the application level Logrus.